### PR TITLE
Fix VariableDeclarator with null initialiser

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ npm install analyse-control --save
 
 ## Introduction
 
+[ECMAScript 5](https://github.com/estree/estree/blob/master/es5.md) and below are supported.
+
 Given this example piece of [ECMAScript 5](https://github.com/estree/estree/blob/master/es5.md) (JavaScript) as input:
 
 ```javascript

--- a/basic_control.js
+++ b/basic_control.js
@@ -185,6 +185,18 @@ flowProgram.with(
 flowProgram.with(
   morphic.number("nodeId"),
   {
+    "type": "VariableDeclarator",
+    "init": null
+  }
+).then(
+  r => [
+    flow({node: r.nodeId, type: "start"}, {node: r.nodeId, type: "end"})
+  ]
+);
+
+flowProgram.with(
+  morphic.number("nodeId"),
+  {
     "type": either([
       "IfStatement",
       "ConditionalExpression"
@@ -645,7 +657,9 @@ flowProgram.with(
 
 flowProgram.otherwise().then(
   (_1, _2, input) => {
-    throw new Error("No specific rules for given " + input.type);
+    throw new Error("No specific rules for given " +
+      input.type +
+      ". This tool only supports ECMAScript 5 and below.");
   }
 );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analyse-control",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "a basic control flow analyser for JavaScript",
   "main": "lib.js",
   "dependencies": {

--- a/test/basic_control.js
+++ b/test/basic_control.js
@@ -179,6 +179,23 @@ describe("simple control flow analysis", function() {
 
   });
 
+  it("should output flow for a VariableDeclarator node with no initialiser", function() {
+
+    // nodeList for an expression statement like `var x;`
+    var nodeList = new List([
+      {
+        "type": "VariableDeclarator",
+        "id": 2
+      }
+    ]);
+
+    var stringRepresentation = flowListToStrings(control(nodeList));
+
+    assert.equal(1, stringRepresentation.size);
+    assert.ok(stringRepresentation.includes("0.start -> 0.end"));
+
+  });
+
   it("should output flow for an IfStatement node without alternative", function() {
 
     // nodeList for an expression statement like `if (true) {}`


### PR DESCRIPTION
Fixes #8 

The code example contains `for (var key in arg) {`. I [missed](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Parser_API#Declarations) that the initialiser for a `VariableDeclarator` can be null.

Because `VariableDeclarator`s are hoisted this is already dealt with in `hoist.js`, so I've just joined the start to the end. This fixes the crash reported in the issue.

I've also tried to improve the error message, because this exception will often occur when ECMAScript > 5 ASTs are analysed.