### PR TITLE
Fix hoist definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,10 @@ the output is `undefined`.
 This library will correctly return `hoist` flows to cover this behaviour. The
 FlowNodes will be marked as `isHoist() == true`
 
-Note this library specifically adheres to the
-[Chrome/IE/Safari](http://code.google.com/p/v8/issues/detail?id=437)
-standard way of hoisting non-standard conditional declarations.
+Note this library adheres to the
+[ECMAScript 5](http://www.ecma-international.org/ecma-262/5.1/#sec-13)
+hoisting definition, where function declarations inside statements are not
+hoisted.
 
 ### `FlowNode.isEnter() : Boolean`
 

--- a/hoist.js
+++ b/hoist.js
@@ -14,16 +14,6 @@ function hoistNode(a, b) {
   };
 }
 
-var blockKeys = [
-  "consequent",
-  "alternate",
-  "body",
-  "test",
-  "init",
-  "left",
-  "declarations"
-];
-
 var dispatcher = new morphic();
 var enumerate = new morphic();
 
@@ -41,23 +31,22 @@ enumerate.with(
   morphic.Object("list"),
   morphic.Number("id"),
   {
-    "type": either([
-      "IfStatement",
-      "LabeledStatement",
-      "BlockStatement",
-      "WhileStatement",
-      "DoWhileStatement",
-      "ForStatement",
-      "ForOfStatement",
-      "ForInStatement",
-      "Program",
-      "VariableDeclaration"
-    ])
+    "type": "Program",
+    "body": morphic.Object("elements")
   }
 ).then(
-  (r, list, id, input) => flatten(blockKeys
-    .filter(key => input[key] != undefined)
-    .map(key => dispatcher(r.list, input[key])))
+  (r, list, id, input) => dispatcher(r.list, r.elements)
+);
+
+enumerate.with(
+  morphic.Object("list"),
+  morphic.Number("id"),
+  {
+    "type": "VariableDeclaration",
+    "declarations": morphic.Object("elements")
+  }
+).then(
+  (r, list, id, input) => dispatcher(r.list, r.elements)
 );
 
 enumerate.with(

--- a/test/hoist.js
+++ b/test/hoist.js
@@ -43,7 +43,7 @@ describe("hoisting", function() {
     assert.ok(stringRepresentation.indexOf("2.hoist -> 0.start") != -1);
   });
 
-  it("should hoist a var declaration in an if block", function() {
+  it("should not hoist a var declaration in an if block", function() {
     // nodeList for `if (false) {var x = true}`
     var nodeList = new List([
       {
@@ -88,13 +88,12 @@ describe("hoisting", function() {
 
     var declarations = hoist(nodeList);
 
-    assert.equal(2, declarations.length);
+    assert.equal(1, declarations.length);
     var stringRepresentation = declarations.map(r =>
       r.start.node + "." + r.start.type + " -> " + r.end.node + "." + r.end.type
     );
 
-    assert.ok(stringRepresentation.indexOf("0.hoist -> 5.hoist") != -1);
-    assert.ok(stringRepresentation.indexOf("5.hoist -> 0.start") != -1);
+    assert.ok(stringRepresentation.indexOf("0.hoist -> 0.start") != -1);
   });
 
   it("should hoist a simple function declaration", function() {
@@ -134,7 +133,7 @@ describe("hoisting", function() {
     assert.ok(stringRepresentation.indexOf("1.hoist -> 0.start") != -1);
   });
 
-  it("should hoist a simple function declaration in an if block", function() {
+  it("should not hoist a simple function declaration in an if block", function() {
     // nodeList for `if (false) {function test() {}}`
     var nodeList = new List([
       {
@@ -176,13 +175,12 @@ describe("hoisting", function() {
 
     var declarations = hoist(nodeList);
 
-    assert.equal(2, declarations.length);
+    assert.equal(1, declarations.length);
     var stringRepresentation = declarations.map(r =>
       r.start.node + "." + r.start.type + " -> " + r.end.node + "." + r.end.type
     );
 
-    assert.ok(stringRepresentation.indexOf("0.hoist -> 4.hoist") != -1);
-    assert.ok(stringRepresentation.indexOf("4.hoist -> 0.start") != -1);
+    assert.ok(stringRepresentation.indexOf("0.hoist -> 0.start") != -1);
   });
 
   it("should hoist in order", function() {


### PR DESCRIPTION
Some function declarations were hoisted incorrectly, but browsers are conformant to the specification now, so this library should be too.